### PR TITLE
Update abstract to be more intriguing

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
   - name: "Kerchunk Cookbook contributors" # use the 'name' field to acknowledge organizations
     website: "https://github.com/ProjectPythia/kerchunk-cookbook/graphs/contributors"
 title: "Kerchunk Cookbook"
-abstract: "Kerchunk 1 is a wrapper to make a netCDF file (and other older file formats) cloud optimized; i.e. makes loading the chunks of the data that you actually want, fast."
+abstract: "Kerchunk provides cloud-friendly access to archival data. With Kerchunk you can read collections of legacy file formats (NetCDF, GRIB2 etc.) as if they were ARCO (Analysis-Ready Cloud-Optimized) formats such as Zarr, without creating a copy of the original dataset."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,4 +9,4 @@ authors:
   - name: "Kerchunk Cookbook contributors" # use the 'name' field to acknowledge organizations
     website: "https://github.com/ProjectPythia/kerchunk-cookbook/graphs/contributors"
 title: "Kerchunk Cookbook"
-abstract: "A Project Pythia Cookbook for Kerchunk."
+abstract: "Kerchunk 1 is a wrapper to make a netCDF file (and other older file formats) cloud optimized; i.e. makes loading the chunks of the data that you actually want, fast."


### PR DESCRIPTION
Closes https://github.com/ProjectPythia/kerchunk-cookbook/issues/39

The tagline shown on the gallery page
<img width="886" alt="image" src="https://github.com/ProjectPythia/kerchunk-cookbook/assets/15331990/9bfb9009-f844-4ab1-aaa1-bd918a26521b">


"A Project Pythia Cookbook for Kerchunk." is too underwhelming and newcomers may completely skip it so I tried to make the abstract more interesting