### PR TITLE
Fix invalid keyword

### DIFF
--- a/notebooks/using_references/Hvplot_Datashader.ipynb
+++ b/notebooks/using_references/Hvplot_Datashader.ipynb
@@ -105,7 +105,7 @@
     "    \"references/Pangeo_Forge/reference.json\",\n",
     "    engine=\"kerchunk\",\n",
     "    storage_options=storage_options,\n",
-    "    open_dataset_options=open_dataset_options,\n",
+    "    **open_dataset_options,\n",
     ")\n",
     "\n",
     "display(ds_kerchunk.hvplot(\"lon\", \"lat\", rasterize=True))  # noqa"


### PR DESCRIPTION
I don't think open_dataset_options is a valid kwarg to `xr.open_dataset`.