### PR TITLE
Execute notebooks on Binder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ copyright: "2024"
 
 execute:
   # To execute notebooks via a binder instead, replace 'cache' with 'binder'
-  execute_notebooks: cache
+  execute_notebooks: binder
   timeout: 600
   allow_errors: False # cells with expected failures must set the `raises-exception` cell tag
 


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Seeing if switching the builds to execute notebooks on the Pythia Binder instead of GitHub Actions resolved #61 